### PR TITLE
Make assets:precompile skip database-connecting initializer code.

### DIFF
--- a/config/initializers/spree.rb
+++ b/config/initializers/spree.rb
@@ -18,16 +18,22 @@ require_dependency "#{Rails.root}/lib/spree_taxon_images"
 # In order to initialize a setting do:
 # config.setting_name = 'new value'
 
-Spree.config do |config|
-  # See Gem spree_core-3.0.1/app/models/spree/app_configuration.rb for all predefined preferences.
-  config.logo = "logo/fix-logotype.png"
+# Avoid this block during assets:precompile, so that a database connection is not required.
+# (A hack to support deployment from a build environment that cannot access the production database.)
+if $IS_ASSETS_PRECOMPILE
 
-  # defaults for US-based store
-  config.currency = 'USD'
-  if Spree::Country.table_exists?
-    country = Spree::Country.find_by_iso('US')
-    config.default_country_id = country.id if country.present?
+  Spree.config do |config|
+    # See Gem spree_core-3.0.1/app/models/spree/app_configuration.rb for all predefined preferences.
+    config.logo = "logo/fix-logotype.png"
+
+    # defaults for US-based store
+    config.currency = 'USD'
+    if Spree::Country.table_exists?
+      country = Spree::Country.find_by_iso('US')
+      config.default_country_id = country.id if country.present?
+    end
   end
+
 end
 
 # Support for Heroku S3 Add-on

--- a/lib/tasks/before_assets_precompile.rake
+++ b/lib/tasks/before_assets_precompile.rake
@@ -1,4 +1,5 @@
 task :before_assets_precompile do
+  $IS_ASSETS_PRECOMPILE = true
   Rake::Task['deface:precompile'].invoke
 end
 


### PR DESCRIPTION
Build teams says there’s no stable way to detect build vs runtime. This is a gross, global workaround.

@ped please review